### PR TITLE
Regenerate a port number if the connection fails

### DIFF
--- a/src/main/java/nl/mawoo/smokesignal/SmokeSignal.java
+++ b/src/main/java/nl/mawoo/smokesignal/SmokeSignal.java
@@ -60,15 +60,14 @@ public class SmokeSignal {
      */
     private static ServerSocket buildSocket() {
         ServerSocket result = null;
-        int port = Util.random4DigitNumber();
         while(result == null) {
             try {
-                result = new ServerSocket(port);
+                result = new ServerSocket(Util.random4DigitNumber());
             } catch (IOException e) {
                 LOGGER.error("Could not connect to port. "+ port, e);
             }
         }
-        LOGGER.info("connection found on port: "+ port);
+        LOGGER.info("connection found on port: "+ result.getLocalPort());
         return result;
     }
 }


### PR DESCRIPTION
The IOException could be thrown because the port is already in use. By generating a new port number we will circumvent this issue.